### PR TITLE
invalidate pooled connections after 404

### DIFF
--- a/src/lhttpc_client.erl
+++ b/src/lhttpc_client.erl
@@ -478,7 +478,7 @@ read_response(State, Vsn, {StatusCode, _} = Status, Hdrs) ->
             Response = handle_response_body(State, Vsn, Status, Hdrs),
             NewHdrs = element(2, Response),
             ReqHdrs = State#client_state.request_headers,
-            NewSocket = maybe_close_socket(Socket, Ssl, Vsn, ReqHdrs, NewHdrs),
+            NewSocket = maybe_close_socket(Socket, StatusCode, Ssl, Vsn, ReqHdrs, NewHdrs),
             {Response, NewSocket};
         {error, closed} ->
             % Either we only noticed that the socket was closed after we
@@ -916,24 +916,30 @@ read_until_closed(Socket, Acc, Hdrs, Ssl) ->
 %%------------------------------------------------------------------------------
 %% @private
 %%------------------------------------------------------------------------------
-maybe_close_socket(Socket, Ssl, {1, Minor}, ReqHdrs, RespHdrs) when Minor >= 1->
+maybe_close_socket(Socket, StatusCode, Ssl, {1, Minor}, ReqHdrs, RespHdrs) when Minor >= 1->
     ClientConnection = ?CONNECTION_HDR(ReqHdrs, "keep-alive"),
     ServerConnection = ?CONNECTION_HDR(RespHdrs, "keep-alive"),
     if
         ClientConnection =:= "close"; ServerConnection =:= "close" ->
             lhttpc_sock:close(Socket, Ssl),
             undefined;
-        ClientConnection =/= "close", ServerConnection =/= "close" ->
+        StatusCode =:= 404 ->
+            lhttpc_sock:close(Socket, Ssl),
+            undefined;
+        true ->
             Socket
     end;
-maybe_close_socket(Socket, Ssl, _, ReqHdrs, RespHdrs) ->
+maybe_close_socket(Socket, StatusCode, Ssl, _, ReqHdrs, RespHdrs) ->
     ClientConnection = ?CONNECTION_HDR(ReqHdrs, "keep-alive"),
     ServerConnection = ?CONNECTION_HDR(RespHdrs, "close"),
     if
         ClientConnection =:= "close"; ServerConnection =/= "keep-alive" ->
             lhttpc_sock:close(Socket, Ssl),
             undefined;
-        ClientConnection =/= "close", ServerConnection =:= "keep-alive" ->
+        StatusCode =:= 404 ->
+            lhttpc_sock:close(Socket, Ssl),
+            undefined;
+        true ->
             Socket
     end.
 


### PR DESCRIPTION
we suspect there may have been a problem where
a keep alive connection was made then a DNS change
occurred but we kept sending requests to an old
server that started to return 404s

since we do not have a good way of invaliding http
connections from outside of lhttpc I have decided
to hardcode the logic to junk connections after
receiving a 404.

i think the only other reasonable alternative
would be to expose an interface to remove all
connections from the pool matching a hostname
and then the client could decide whether the
connection needs invalidation based on its own
suspicions. 

in a perfect world the client could decide
whether to invalidate on a connection by
connection basis but this doesn't seem possible
because the lhttpc interface is a request/response
interface and doesn't expose connection handling
to the client. however, one way of doing it would
be to allow the client to specify a callback which
would allow the client to determine whether the 
connection is 'bad' or not before returning the
connection to the pool.